### PR TITLE
Fix rate limit API

### DIFF
--- a/scripts/requisitos.php
+++ b/scripts/requisitos.php
@@ -216,8 +216,8 @@ for ($row = 2, $i = 1; $row <= $highestRow; $row++) {
     if ($issues) {
         if ($incidencia === null) {
             if ($i++ % 10 === 0) {
-                echo '# Deteniendo la ejecución por 5 segundos para no exceder el límite de tasa...';
-                sleep(5);
+                echo '# Deteniendo la ejecución por 20 segundos para no exceder el límite de tasa...';
+                sleep(20);
                 echo "\n";
             }
             echo "Generando incidencia para $codigo en GitHub...";


### PR DESCRIPTION
La detención de 5 segundos en la creación de issues era insuficiente. Cambiándolo a 20 segundos evita que exceda la limitación de 30 solicitudes por minuto en la API.

https://docs.github.com/en/rest/search#rate-limit